### PR TITLE
Bump default family version to latest redis family

### DIFF
--- a/redis.cfhighlander.rb
+++ b/redis.cfhighlander.rb
@@ -26,7 +26,7 @@ CfhighlanderTemplate do
     ComponentParam 'SnapshotRetentionLimit',
       description: 'The number of days for which ElastiCache retains automatic snapshots before deleting them.'
 
-    ComponentParam 'InstanceType', 't3.small',
+    ComponentParam 'InstanceType', 'cache.t3.small',
       description: 'The compute and memory capacity of the nodes in the node group (shard)'
 
     ComponentParam 'Subnets', type: 'CommaDelimitedList',

--- a/redis.cfndsl.rb
+++ b/redis.cfndsl.rb
@@ -118,7 +118,7 @@ CloudFormation do
   dns_domain = external_parameters.fetch(:dns_domain)
   record = external_parameters.fetch(:record, 'redis')
 
-  if !external_parameters[:create_route53_record]
+  if external_parameters[:create_route53_record]
     Route53_RecordSet(:HostRecordRedis) {
       HostedZoneName FnSub("#{dns_domain}.")
       Name FnSub("#{record}.#{dns_domain}.")

--- a/redis.cfndsl.rb
+++ b/redis.cfndsl.rb
@@ -38,7 +38,7 @@ CloudFormation do
   }
 
   custom_parameters = external_parameters.fetch(:parameters, [])
-  family = external_parameters.fetch(:family, 'redis4.0')
+  family = external_parameters.fetch(:family, 'redis6.0')
   cluster_enabled = external_parameters.fetch(:cluster_enabled, 'true')
 
   if cluster_enabled

--- a/redis.cfndsl.rb
+++ b/redis.cfndsl.rb
@@ -118,12 +118,14 @@ CloudFormation do
   dns_domain = external_parameters.fetch(:dns_domain)
   record = external_parameters.fetch(:record, 'redis')
 
-  Route53_RecordSet(:HostRecordRedis) {
-    HostedZoneName FnSub("#{dns_domain}.")
-    Name FnSub("#{record}.#{dns_domain}.")
-    Type 'CNAME'
-    TTL '60'
-    ResourceRecords [ FnGetAtt(:ReplicationGroupRedis, record_endpoint) ]
-  }
+  if !external_parameters[:create_route53_record]
+    Route53_RecordSet(:HostRecordRedis) {
+      HostedZoneName FnSub("#{dns_domain}.")
+      Name FnSub("#{record}.#{dns_domain}.")
+      Type 'CNAME'
+      TTL '60'
+      ResourceRecords [ FnGetAtt(:ReplicationGroupRedis, record_endpoint) ]
+    }
+  end
 
 end

--- a/redis.cfndsl.rb
+++ b/redis.cfndsl.rb
@@ -117,8 +117,9 @@ CloudFormation do
 
   dns_domain = external_parameters.fetch(:dns_domain)
   record = external_parameters.fetch(:record, 'redis')
+  create_route53_record = external_parameters.fetch(:create_route53_record)
 
-  if !external_parameters[:create_route53_record]
+  if create_route53_record.eql?(false)
     Route53_RecordSet(:HostRecordRedis) {
       HostedZoneName FnSub("#{dns_domain}.")
       Name FnSub("#{record}.#{dns_domain}.")

--- a/redis.cfndsl.rb
+++ b/redis.cfndsl.rb
@@ -117,9 +117,8 @@ CloudFormation do
 
   dns_domain = external_parameters.fetch(:dns_domain)
   record = external_parameters.fetch(:record, 'redis')
-  create_route53_record = external_parameters.fetch(:create_route53_record)
 
-  if create_route53_record.eql?(false)
+  if !external_parameters[:create_route53_record]
     Route53_RecordSet(:HostRecordRedis) {
       HostedZoneName FnSub("#{dns_domain}.")
       Name FnSub("#{record}.#{dns_domain}.")

--- a/redis.cfndsl.rb
+++ b/redis.cfndsl.rb
@@ -38,7 +38,7 @@ CloudFormation do
   }
 
   custom_parameters = external_parameters.fetch(:parameters, [])
-  family = external_parameters.fetch(:family, 'redis6.0')
+  family = external_parameters.fetch(:family, 'redis6.x')
   cluster_enabled = external_parameters.fetch(:cluster_enabled, 'true')
 
   if cluster_enabled

--- a/redis.config.yaml
+++ b/redis.config.yaml
@@ -1,4 +1,5 @@
 dns_domain: ${EnvironmentName}.${DnsDomain}
+create_route53_record: true
 
 # Engine version is not set by default, this value must be provided
 # engine_version: 4.0.10


### PR DESCRIPTION
When supplying no value for engine version & engine family it should default to the latest version. For engine version it's okay to supply no value for the resource parameter, but for `CacheParameterGroupFamily` a value is required so we must hardcode a default, which should be the latest version availiable.