### PR TITLE
fix: conditionally include SnapshotRetentionLimit and add SnapshottingClusterId

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | SnapshotName | The name of a snapshot from which to restore data into the new replication group |  | false | String
 | SnapshotArns | A list of ARNs that uniquely identify the Redis RDB snapshot files stored in S3 | | false | String
 | SnapshotRetentionLimit | The number of days for which ElastiCache retains automatic snapshots before deleting them | | false | Integer
+| SnapshottingClusterId | The cluster ID used as the daily snapshot source for the replication group | | false | String
 | NumNodeGroups | Specifies the number of node groups (shards) for this Redis replication group | 1 | false | Integer |
 | ReplicasPerNodeGroup | An optional parameter that specifies the number of replica nodes in each node group (shard) | 0 | false | Integer | [0, 1, 2, 3, 4, 5]
 | NumCacheClusters | The number of clusters this replication group initially has | 2 | false | Integer | [1, 2, 3, 4, 5, 6]
@@ -97,6 +98,31 @@ snapshot_restore_type: s3
 This will enable the below parameter:
 
 - **SnapshotArns** A list of ARNs that uniquely identify the Redis RDB snapshot files stored in S3
+
+### Automatic Backups
+
+By default, `SnapshotRetentionLimit` and `SnapshottingClusterId` are omitted from the CloudFormation resource, leaving any manually configured backup settings untouched.
+
+To enable automatic backups via CloudFormation:
+
+**New clusters** — set `SnapshotRetentionLimit` only. ElastiCache automatically assigns the primary node as the snapshotting cluster:
+
+```yaml
+SnapshotRetentionLimit: 7
+```
+
+**Existing clusters** — both `SnapshotRetentionLimit` and `SnapshottingClusterId` are required when enabling backups on an existing cluster:
+
+```yaml
+SnapshotRetentionLimit: 7
+SnapshottingClusterId: my-cluster-001
+```
+
+**Disable automatic backups:**
+
+```yaml
+SnapshotRetentionLimit: 0
+```
 
 ### Encryption Configuration
 

--- a/redis.cfhighlander.rb
+++ b/redis.cfhighlander.rb
@@ -24,6 +24,9 @@ CfhighlanderTemplate do
     ComponentParam 'SnapshotRetentionLimit',
       description: 'The number of days for which ElastiCache retains automatic snapshots before deleting them.'
 
+    ComponentParam 'SnapshottingClusterId', '',
+      description: 'The cluster ID that is used as the daily snapshot source for the replication group. Required when enabling SnapshotRetentionLimit.'
+
     ComponentParam 'InstanceType', 'cache.t3.small',
       description: 'The compute and memory capacity of the nodes in the node group (shard)'
 

--- a/redis.cfndsl.rb
+++ b/redis.cfndsl.rb
@@ -82,6 +82,8 @@ CloudFormation do
   Condition('DataTieringEnabled', FnEquals(Ref(:DataTieringEnabled), 'true'))
   Condition('NoSnapshotNamEnabled', FnEquals(Ref(:SnapshotName), ''))
   Condition('NoSnapshotArnsEnabled', FnEquals(Ref(:SnapshotArns), ''))
+  Condition('SnapshotRetentionEnabled', FnNot(FnEquals(Ref(:SnapshotRetentionLimit), '')))
+  Condition('SnapshottingClusterIdEnabled', FnNot(FnEquals(Ref(:SnapshottingClusterId), '')))
 
   engine = external_parameters.fetch(:engine, 'redis')
 
@@ -117,7 +119,8 @@ CloudFormation do
 
     SnapshotName FnIf('NoSnapshotNamEnabled', Ref('AWS::NoValue'), Ref(:SnapshotName))
     SnapshotArns FnIf('NoSnapshotArnsEnabled', Ref('AWS::NoValue'), FnSplit(",", Ref(:SnapshotArns)))
-    SnapshotRetentionLimit Ref(:SnapshotRetentionLimit)
+    SnapshotRetentionLimit FnIf('SnapshotRetentionEnabled', Ref(:SnapshotRetentionLimit), Ref('AWS::NoValue'))
+    SnapshottingClusterId FnIf('SnapshottingClusterIdEnabled', Ref(:SnapshottingClusterId), Ref('AWS::NoValue'))
 
     SnapshotWindow snapshot_window unless snapshot_window.nil?
     PreferredMaintenanceWindow maintenance_window unless maintenance_window.nil?

--- a/spec/cache-cluster_spec.rb
+++ b/spec/cache-cluster_spec.rb
@@ -140,7 +140,11 @@ describe 'compiled component redis' do
       end
       
       it "to have property SnapshotRetentionLimit" do
-          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Ref"=>"SnapshotRetentionLimit"})
+          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Fn::If"=>["SnapshotRetentionEnabled", {"Ref"=>"SnapshotRetentionLimit"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+
+      it "to have property SnapshottingClusterId" do
+          expect(resource["Properties"]["SnapshottingClusterId"]).to eq({"Fn::If"=>["SnapshottingClusterIdEnabled", {"Ref"=>"SnapshottingClusterId"}, {"Ref"=>"AWS::NoValue"}]})
       end
       
       it "to have property Tags" do

--- a/spec/clustered_spec.rb
+++ b/spec/clustered_spec.rb
@@ -152,7 +152,11 @@ describe 'compiled component redis' do
       end
       
       it "to have property SnapshotRetentionLimit" do
-          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Ref"=>"SnapshotRetentionLimit"})
+          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Fn::If"=>["SnapshotRetentionEnabled", {"Ref"=>"SnapshotRetentionLimit"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+
+      it "to have property SnapshottingClusterId" do
+          expect(resource["Properties"]["SnapshottingClusterId"]).to eq({"Fn::If"=>["SnapshottingClusterIdEnabled", {"Ref"=>"SnapshottingClusterId"}, {"Ref"=>"AWS::NoValue"}]})
       end
       
       it "to have property SnapshotWindow" do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -144,7 +144,11 @@ describe 'compiled component redis' do
       end
       
       it "to have property SnapshotRetentionLimit" do
-          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Ref"=>"SnapshotRetentionLimit"})
+          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Fn::If"=>["SnapshotRetentionEnabled", {"Ref"=>"SnapshotRetentionLimit"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+
+      it "to have property SnapshottingClusterId" do
+          expect(resource["Properties"]["SnapshottingClusterId"]).to eq({"Fn::If"=>["SnapshottingClusterIdEnabled", {"Ref"=>"SnapshottingClusterId"}, {"Ref"=>"AWS::NoValue"}]})
       end
       
       it "to have property Tags" do

--- a/spec/node-group_spec.rb
+++ b/spec/node-group_spec.rb
@@ -144,7 +144,11 @@ describe 'compiled component redis' do
       end
       
       it "to have property SnapshotRetentionLimit" do
-          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Ref"=>"SnapshotRetentionLimit"})
+          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Fn::If"=>["SnapshotRetentionEnabled", {"Ref"=>"SnapshotRetentionLimit"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+
+      it "to have property SnapshottingClusterId" do
+          expect(resource["Properties"]["SnapshottingClusterId"]).to eq({"Fn::If"=>["SnapshottingClusterIdEnabled", {"Ref"=>"SnapshottingClusterId"}, {"Ref"=>"AWS::NoValue"}]})
       end
       
       it "to have property Tags" do

--- a/spec/non-clustered_spec.rb
+++ b/spec/non-clustered_spec.rb
@@ -144,7 +144,11 @@ describe 'compiled component redis' do
       end
       
       it "to have property SnapshotRetentionLimit" do
-          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Ref"=>"SnapshotRetentionLimit"})
+          expect(resource["Properties"]["SnapshotRetentionLimit"]).to eq({"Fn::If"=>["SnapshotRetentionEnabled", {"Ref"=>"SnapshotRetentionLimit"}, {"Ref"=>"AWS::NoValue"}]})
+      end
+
+      it "to have property SnapshottingClusterId" do
+          expect(resource["Properties"]["SnapshottingClusterId"]).to eq({"Fn::If"=>["SnapshottingClusterIdEnabled", {"Ref"=>"SnapshottingClusterId"}, {"Ref"=>"AWS::NoValue"}]})
       end
       
       it "to have property Tags" do


### PR DESCRIPTION
## Problem

`SnapshotRetentionLimit` was unconditionally passed as a `Ref` to the ReplicationGroup resource. When the parameter was an empty string (default), CloudFormation threw an Integer type validation error on any stack update:

```
Properties validation failed: #/SnapshotRetentionLimit: expected type: Integer, found: String
```

Additionally, setting `SnapshotRetentionLimit` to a value required `SnapshottingClusterId` which the component didn't support:

```
Must specify both SnapshotRetentionLimit and SnapshottingClusterId to turn on snapshots
```

## Fix

- `SnapshotRetentionLimit`: uses `AWS::NoValue` when empty, leaving manual backup config untouched
- `SnapshottingClusterId`: new parameter, also uses `AWS::NoValue` when empty

## Behaviour

| SnapshotRetentionLimit | SnapshottingClusterId | Result |
|---|---|---|
| empty (default) | empty (default) | Both omitted — manual config untouched |
| 7 | cluster-001 | CloudFormation manages backups |
| 0 | empty | Disables automatic backups |